### PR TITLE
Add Standard JSR-330 Dynamic Resolution API

### DIFF
--- a/examples/dynamic-resolver/pom.xml
+++ b/examples/dynamic-resolver/pom.xml
@@ -42,24 +42,55 @@
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.glassfish.hk2</groupId>
-        <artifactId>hk2-parent</artifactId>
+        <artifactId>examples</artifactId>
         <version>2.4.0-b08-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>examples</artifactId>
-    <packaging>pom</packaging>
-    <name>Examples of various use cases</name>
+    <artifactId>dynamic-resolver-example</artifactId>
+    <name>Dynamic Resolver Example</name>
+    <description>A use case for dynamic injection resolution</description>
 
-    <modules>
-        <module>ctm</module>
-        <module>custom-resolver</module>
-        <module>security-lockdown</module>
-        <module>caching</module>
-        <module>events</module>
-        <module>configuration</module>
-        <module>dynamic-resolver</module>
-    </modules>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.glassfish.hk2</groupId>
+                <artifactId>osgiversion-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish.hk2.external</groupId>
+            <artifactId>javax.inject</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.hk2.external</groupId>
+            <artifactId>asm-all-repackaged</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.hk2</groupId>
+            <artifactId>hk2-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.hk2</groupId>
+            <artifactId>hk2-locator</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/examples/dynamic-resolver/src/main/java/org/glassfish/hk2/dynamic/resolver/Airline.java
+++ b/examples/dynamic-resolver/src/main/java/org/glassfish/hk2/dynamic/resolver/Airline.java
@@ -1,0 +1,61 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.dynamic.resolver;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import java.lang.annotation.Target;
+import javax.inject.Qualifier;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+@Qualifier
+@Retention(RUNTIME)
+@Target({TYPE, METHOD, FIELD, PARAMETER})
+public @interface Airline {
+
+    String value() default "";
+}

--- a/examples/dynamic-resolver/src/main/java/org/glassfish/hk2/dynamic/resolver/AirlineFlightDynamicResolver.java
+++ b/examples/dynamic-resolver/src/main/java/org/glassfish/hk2/dynamic/resolver/AirlineFlightDynamicResolver.java
@@ -1,0 +1,61 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.dynamic.resolver;
+
+import org.glassfish.hk2.api.DynamicInjectee;
+import org.glassfish.hk2.api.DynamicResolver;
+import org.jvnet.hk2.annotations.Service;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+@Airline
+@Service
+public class AirlineFlightDynamicResolver implements DynamicResolver<Flight> {
+
+    @Override
+    public Flight resolve(DynamicInjectee<Flight> injectee) {
+        //create a new Flight from scratch. note that you can inject services
+        //into the resolver to help you construct or retrieve Flight instances.
+        return new Flight(new Plane(new EngineImpl("Royce Royce", 93000)));
+    }
+
+}

--- a/examples/dynamic-resolver/src/main/java/org/glassfish/hk2/dynamic/resolver/Boeing.java
+++ b/examples/dynamic-resolver/src/main/java/org/glassfish/hk2/dynamic/resolver/Boeing.java
@@ -1,0 +1,60 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.dynamic.resolver;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import java.lang.annotation.Target;
+import javax.inject.Qualifier;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+@Qualifier
+@Retention(RUNTIME)
+@Target({TYPE, METHOD, FIELD, PARAMETER})
+public @interface Boeing {
+
+}

--- a/examples/dynamic-resolver/src/main/java/org/glassfish/hk2/dynamic/resolver/BoeingDynamicResolver.java
+++ b/examples/dynamic-resolver/src/main/java/org/glassfish/hk2/dynamic/resolver/BoeingDynamicResolver.java
@@ -1,0 +1,61 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.dynamic.resolver;
+
+import org.glassfish.hk2.api.DynamicInjectee;
+import org.glassfish.hk2.api.DynamicResolver;
+import org.jvnet.hk2.annotations.Service;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+@Boeing
+@Service
+public class BoeingDynamicResolver implements DynamicResolver {
+
+    @Override
+    public Object resolve(DynamicInjectee injectee) {
+        //create a new Plane from scratch. note that you can inject services
+        //into the resolver to help you construct or retrieve Plane instances.
+        return new Plane(new EngineImpl("Royce Royce", 93000));
+    }
+
+}

--- a/examples/dynamic-resolver/src/main/java/org/glassfish/hk2/dynamic/resolver/BoeingDynamicResolver.java
+++ b/examples/dynamic-resolver/src/main/java/org/glassfish/hk2/dynamic/resolver/BoeingDynamicResolver.java
@@ -49,10 +49,10 @@ import org.jvnet.hk2.annotations.Service;
  */
 @Boeing
 @Service
-public class BoeingDynamicResolver implements DynamicResolver {
+public class BoeingDynamicResolver implements DynamicResolver<Object> {
 
     @Override
-    public Object resolve(DynamicInjectee injectee) {
+    public Object resolve(DynamicInjectee<Object> injectee) {
         //create a new Plane from scratch. note that you can inject services
         //into the resolver to help you construct or retrieve Plane instances.
         return new Plane(new EngineImpl("Royce Royce", 93000));

--- a/examples/dynamic-resolver/src/main/java/org/glassfish/hk2/dynamic/resolver/Engine.java
+++ b/examples/dynamic-resolver/src/main/java/org/glassfish/hk2/dynamic/resolver/Engine.java
@@ -1,0 +1,52 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.dynamic.resolver;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+public interface Engine {
+
+    String getManufacturer();
+
+    int getThrust();
+
+}

--- a/examples/dynamic-resolver/src/main/java/org/glassfish/hk2/dynamic/resolver/EngineImpl.java
+++ b/examples/dynamic-resolver/src/main/java/org/glassfish/hk2/dynamic/resolver/EngineImpl.java
@@ -1,0 +1,67 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.dynamic.resolver;
+
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+public class EngineImpl implements Engine {
+
+    private final String manufacturer;
+    private final int thrust;
+
+    public EngineImpl(String manufacturer, int thrust) {
+        this.manufacturer = manufacturer;
+        this.thrust = thrust;
+    }
+
+    @Override
+    public String getManufacturer() {
+        return manufacturer;
+    }
+
+    @Override
+    public int getThrust() {
+        return thrust;
+    }
+
+}

--- a/examples/dynamic-resolver/src/main/java/org/glassfish/hk2/dynamic/resolver/EngineTypeDynamicResolver.java
+++ b/examples/dynamic-resolver/src/main/java/org/glassfish/hk2/dynamic/resolver/EngineTypeDynamicResolver.java
@@ -1,0 +1,59 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.dynamic.resolver;
+
+import org.glassfish.hk2.api.DynamicInjectee;
+import org.glassfish.hk2.api.DynamicResolver;
+import org.jvnet.hk2.annotations.Service;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+@Service
+public class EngineTypeDynamicResolver implements DynamicResolver<Engine> {
+
+    @Override
+    public Engine resolve(DynamicInjectee<Engine> injectee) {
+        //create a new engine instance dynamically.
+        return new EngineImpl("Pratt & Whitney", 98000);
+    }
+
+}

--- a/examples/dynamic-resolver/src/main/java/org/glassfish/hk2/dynamic/resolver/Flight.java
+++ b/examples/dynamic-resolver/src/main/java/org/glassfish/hk2/dynamic/resolver/Flight.java
@@ -1,0 +1,63 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.dynamic.resolver;
+
+import javax.inject.Inject;
+import org.jvnet.hk2.annotations.Service;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+@Service
+public class Flight {
+
+    private final Plane plane;
+
+    @Inject
+    Flight(@Boeing Plane plane) {
+        this.plane = plane;
+    }
+
+    public Plane getPlane() {
+        return plane;
+    }
+
+}

--- a/examples/dynamic-resolver/src/main/java/org/glassfish/hk2/dynamic/resolver/Plane.java
+++ b/examples/dynamic-resolver/src/main/java/org/glassfish/hk2/dynamic/resolver/Plane.java
@@ -1,0 +1,63 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.dynamic.resolver;
+
+import javax.inject.Inject;
+import org.jvnet.hk2.annotations.Service;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+@Service
+public class Plane {
+
+    private final Engine engine;
+
+    @Inject
+    Plane(Engine engine) {
+        this.engine = engine;
+    }
+
+    public Engine getEngine() {
+        return engine;
+    }
+
+}

--- a/examples/dynamic-resolver/src/main/java/org/glassfish/hk2/dynamic/resolver/Traveler.java
+++ b/examples/dynamic-resolver/src/main/java/org/glassfish/hk2/dynamic/resolver/Traveler.java
@@ -1,0 +1,63 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.dynamic.resolver;
+
+import javax.inject.Inject;
+import org.jvnet.hk2.annotations.Service;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+@Service
+public class Traveler {
+
+    private final Flight flight;
+
+    @Inject
+    Traveler(@Airline("United") Flight flight) {
+        this.flight = flight;
+    }
+
+    public Flight getFlight() {
+        return flight;
+    }
+
+}

--- a/examples/dynamic-resolver/src/test/java/org/glassfish/hk2/dynamic/resolver/DynamicResolverModule.java
+++ b/examples/dynamic-resolver/src/test/java/org/glassfish/hk2/dynamic/resolver/DynamicResolverModule.java
@@ -1,0 +1,62 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.dynamic.resolver;
+
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+public class DynamicResolverModule extends AbstractBinder {
+
+    @Override
+    protected void configure() {
+        //Dynamic Type Injection
+        addActiveDescriptor(EngineTypeDynamicResolver.class);
+        addActiveDescriptor(BoeingDynamicResolver.class);
+        addActiveDescriptor(AirlineFlightDynamicResolver.class);
+        addActiveDescriptor(Plane.class);
+        addActiveDescriptor(Flight.class);
+        addActiveDescriptor(Traveler.class);
+
+    }
+
+}

--- a/examples/dynamic-resolver/src/test/java/org/glassfish/hk2/dynamic/resolver/DynamicResolverTest.java
+++ b/examples/dynamic-resolver/src/test/java/org/glassfish/hk2/dynamic/resolver/DynamicResolverTest.java
@@ -1,0 +1,88 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.dynamic.resolver;
+
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.api.ServiceLocatorFactory;
+import org.glassfish.hk2.utilities.ServiceLocatorUtilities;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+public class DynamicResolverTest {
+
+    private ServiceLocator locator;
+
+    /**
+     * For Junit, does this before every test
+     */
+    @Before
+    public void doBefore() {
+        locator = ServiceLocatorFactory.getInstance().create("DynamicResolverTest");
+        ServiceLocatorUtilities.bind(locator, new DynamicResolverModule());
+
+    }
+
+    @Test
+    public void testEngineTypeDynamicResolution() {
+        Plane result = locator.getService(Plane.class);
+        Assert.assertNotNull(result);
+        Assert.assertNotNull(result.getEngine());
+    }
+
+    @Test
+    public void testBoeingQualifierDynamicResolution() {
+        Flight result = locator.getService(Flight.class);
+        Assert.assertNotNull(result);
+        Assert.assertNotNull(result.getPlane());
+    }
+
+    @Test
+    public void testAilineFlightQualifiedTypeDynamicResolution() {
+        Traveler result = locator.getService(Traveler.class);
+        Assert.assertNotNull(result);
+        Assert.assertNotNull(result.getFlight());
+    }
+
+}

--- a/hk2-api/src/main/java/org/glassfish/hk2/api/DynamicInjectee.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/api/DynamicInjectee.java
@@ -66,12 +66,12 @@ public interface DynamicInjectee<T> {
      * Get the given qualifier type from the set of qualifiers associated with
      * this injectee.
      *
-     * @param <T> the type of the qualifier
+     * @param <A> the type of the qualifier
      * @param type the qualifier class
      * @return Will return a specified qualifier annotation or null the dynamic
      * injectee doesn't contain the qualifier.
      */
-    public <T extends Annotation> T getQualifier(Class<T> type);
+    public <A extends Annotation> A getQualifier(Class<A> type);
 
     /**
      * This is the set of qualifiers for this dynamic injectee. All of these

--- a/hk2-api/src/main/java/org/glassfish/hk2/api/DynamicInjectee.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/api/DynamicInjectee.java
@@ -1,0 +1,126 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.api;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.util.Set;
+
+/**
+ * An DynamicInjectee represents the point of injection. It can be used by
+ * {@linkplain DynamicResolver dynamic injection resolvers} to discover all of
+ * the information available about the entity being injected into.
+ *
+ * @author Sharmarke Aden (saden)
+ * @param <T> This must be the class of the dynamic injectee.
+ */
+public interface DynamicInjectee<T> {
+
+    /**
+     * This is the dynamic type of the injectee. The object that is injected
+     * into this point must be type-safe with regards to this type
+     *
+     * @return The type that this injectee is expecting. Any object injected
+     * into this injection point must be type-safe with regards to this type
+     */
+    public T getType();
+
+    /**
+     * Get the given qualifier type from the set of qualifiers associated with
+     * this injectee.
+     *
+     * @param <T> the type of the qualifier
+     * @param type the qualifier class
+     * @return Will return a specified qualifier annotation or null the dynamic
+     * injectee doesn't contain the qualifier.
+     */
+    public <T extends Annotation> T getQualifier(Class<T> type);
+
+    /**
+     * This is the set of qualifiers for this dynamic injectee. All of these
+     * qualifiers must be present on the {@link DynamicResolver} class as well
+     * as the implementation class of the object that is injected into this
+     * injectee. Note that the fields of the annotation must also match
+     *
+     * @return Will not return null, but may return an empty set. The set of all
+     * qualifiers that must match.
+     */
+    public Set<Annotation> getQualifiers();
+
+    /**
+     * If this Injectee is a constructor or method parameter, this will return
+     * the index of the parameter. If this Injectee is a field, this will return
+     * -1
+     *
+     * @return the position of the parameter, or -1 if this is a field
+     */
+    public int getPosition();
+
+    /**
+     * Returns the parent class for this injectee. This is the class of the
+     * object that will be injected into. This field may return null if this is
+     * from a service lookup
+     *
+     * @return The class of the object that will be injected into
+     */
+    public Class<?> getParentClass();
+
+    /**
+     * If this Injectee is in a constructor this will return the constructor
+     * being injected into. If this Injectee is in a method this will return the
+     * method being injected into. If this injectee represents a field, this
+     * will return the field being injected into. This injectee may be neither
+     * in which case this will return null
+     *
+     * @return The parent of the injectee, which may be null
+     */
+    public AnnotatedElement getParent();
+
+    /**
+     * This method returns true if this injection point is annotated with
+     * &#86;Optional. In this case if there is no definition for the injection
+     * point in the system it is allowable for the system to merely return null
+     *
+     * @return true if the injection point is annotated with &#86;Optional,
+     * false otherwise
+     */
+    public boolean isOptional();
+
+}

--- a/hk2-api/src/main/java/org/glassfish/hk2/api/DynamicResolver.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/api/DynamicResolver.java
@@ -1,0 +1,95 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.api;
+
+import org.jvnet.hk2.annotations.Contract;
+
+/**
+ * This class allows users to provide a custom injection target for &#64;Inject.
+ * <p>
+ * Using Dynamic Resolvers one can perform three types of dynamic injection
+ * resolution:
+ * </p>
+ * <ol>
+ * <li>Dynamic Type Injection (dynamic resolution of a specific type)</li>
+ * <li>Dynamic Qualified Injection (dynamic resolution of any type with a
+ * specific qualifier(s))</li>
+ * <li>Dynamic Qualified Type Injection (dynamic resolution of a specific type
+ * with a specific qualifier(s)</li>
+ * </ol>
+ *
+ * <p>
+ * Note that for dynamic qualified injection the qualifier must be placed on the
+ * DynamicResolver implementation.
+ * </p>
+ *
+ * <p>
+ * An implementation of DynamicResolver must be in the Singleton scope.
+ * Implementations of DynamicResolver will be instantiated as soon as they are
+ * added to HK2 in order to avoid deadlocks and circular references. Therefore
+ * it is recommended that implementations of InjectionResolver make liberal use
+ * of {@link javax.inject.Provider} or {@link IterableProvider} when injecting
+ * dependent services so that these services are not instantiated when the
+ * DynamicResolver is created
+ * </p>
+ *
+ * @author Sharmarke Aden
+ * @param <T> This must be the class of the dynamic injection type that this
+ * resolver will handle.
+ */
+@Contract
+public interface DynamicResolver<T> {
+
+    /**
+     * This method will return the object that should be injected into the given
+     * dynamic injection point. It is the responsibility of the implementation
+     * to ensure that the object returned can be safely injected into the
+     * injection point.
+     * <p>
+     * This method should not do the injection themselves
+     *
+     * @param injectee The dynamic injection point this value is being injected
+     * into
+     *
+     * @return the object that will be injected.
+     */
+    public T resolve(DynamicInjectee<T> injectee);
+
+}

--- a/hk2-api/src/main/java/org/glassfish/hk2/utilities/DynamicInjecteeImpl.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/utilities/DynamicInjecteeImpl.java
@@ -1,0 +1,147 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.utilities;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.Type;
+import java.util.Set;
+import org.glassfish.hk2.api.DynamicInjectee;
+import org.glassfish.hk2.utilities.reflection.Pretty;
+
+/**
+ * This is an implementation of the DynamicInjectee interface. Using this
+ * implementation may make your code more portable, as new methods added to the
+ * interface will be reflected in this class.
+ *
+ * @author saden@author Sharmarke Aden (saden)
+ * @param <T>
+ *
+ */
+public class DynamicInjecteeImpl<T extends Type> implements DynamicInjectee<T> {
+
+    private final Type type;
+    private final Set<Annotation> qualifiers;
+    private final Class<?> parentClass;
+    private final AnnotatedElement parent;
+    private int position = -1;
+    private boolean optional = false;
+
+    public DynamicInjecteeImpl(Type type,
+            Set<Annotation> qualifiers,
+            int position,
+            boolean optional,
+            Class<?> parentClass,
+            AnnotatedElement parent) {
+        this.type = type;
+        this.qualifiers = qualifiers;
+        this.parentClass = parentClass;
+        this.parent = parent;
+        this.position = position;
+        this.optional = optional;
+    }
+
+    /**
+     * This is the copy constructor, which will copy all the values from the
+     * incoming dynamic instance.
+     *
+     * @param copyMe The non-null Injectee to copy the values from
+     */
+    public DynamicInjecteeImpl(DynamicInjectee<T> copyMe) {
+        type = copyMe.getType();
+        position = copyMe.getPosition();
+        parent = copyMe.getParent();
+        parentClass = copyMe.getParentClass();
+        qualifiers = copyMe.getQualifiers();
+        optional = copyMe.isOptional();
+    }
+
+    @Override
+    public T getType() {
+        return (T) type;
+    }
+
+    @Override
+    public Set<Annotation> getQualifiers() {
+        return qualifiers;
+    }
+
+    @Override
+    public <T extends Annotation> T getQualifier(Class<T> type) {
+        for (Annotation qualifier : qualifiers) {
+            if (qualifier.annotationType().equals(type)) {
+                return (T) qualifier;
+            }
+        }
+
+        return null;
+    }
+
+    @Override
+    public int getPosition() {
+        return position;
+    }
+
+    @Override
+    public Class<?> getParentClass() {
+        return parentClass;
+    }
+
+    @Override
+    public AnnotatedElement getParent() {
+        return parent;
+    }
+
+    @Override
+    public boolean isOptional() {
+        return optional;
+    }
+
+    @Override
+    public String toString() {
+        return "DynamicImpl(type=" + Pretty.type(type)
+                + ",parent=" + Pretty.clazz(parentClass)
+                + ",qualifier=" + Pretty.collection(qualifiers)
+                + ",position=" + position
+                + ",optional=" + optional
+                + "," + System.identityHashCode(this) + ")";
+    }
+
+}

--- a/hk2-api/src/main/java/org/glassfish/hk2/utilities/DynamicInjecteeImpl.java
+++ b/hk2-api/src/main/java/org/glassfish/hk2/utilities/DynamicInjecteeImpl.java
@@ -104,10 +104,10 @@ public class DynamicInjecteeImpl<T extends Type> implements DynamicInjectee<T> {
     }
 
     @Override
-    public <T extends Annotation> T getQualifier(Class<T> type) {
+    public <A extends Annotation> A getQualifier(Class<A> type) {
         for (Annotation qualifier : qualifiers) {
             if (qualifier.annotationType().equals(type)) {
-                return (T) qualifier;
+                return (A) qualifier;
             }
         }
 

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/DynamicResolverModule.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/DynamicResolverModule.java
@@ -1,0 +1,128 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.tests.locator.dynamicresolver;
+
+import org.glassfish.hk2.api.DynamicConfiguration;
+import org.glassfish.hk2.api.DynamicResolver;
+import org.glassfish.hk2.tests.locator.dynamicresolver.contract.ContractInjectedService;
+import org.glassfish.hk2.tests.locator.dynamicresolver.contract.DynamicContractResolver;
+import org.glassfish.hk2.tests.locator.dynamicresolver.misc.NonDynamicTypeInjectedService;
+import org.glassfish.hk2.tests.locator.dynamicresolver.misc.OptionalNonDynamicTypeInjectedService;
+import org.glassfish.hk2.tests.locator.dynamicresolver.misc.OptionalQualifedInjectedService;
+import org.glassfish.hk2.tests.locator.dynamicresolver.misc.OptionalQualifedTypeInjectedService;
+import org.glassfish.hk2.tests.locator.dynamicresolver.misc.OptionalTypeInjectedService;
+import org.glassfish.hk2.tests.locator.dynamicresolver.misc.UntypedAndUnqualifiedResolver;
+import org.glassfish.hk2.tests.locator.dynamicresolver.qualifed.DynamicQualifedResolver;
+import org.glassfish.hk2.tests.locator.dynamicresolver.qualifed.DynamicQualifiedQualifer;
+import org.glassfish.hk2.tests.locator.dynamicresolver.qualifed.QualifedInjectedService;
+import org.glassfish.hk2.tests.locator.dynamicresolver.qualifedType.DynamicQualifedTypeResolver;
+import org.glassfish.hk2.tests.locator.dynamicresolver.qualifedType.DynamicQualifiedTypeQualifer;
+import org.glassfish.hk2.tests.locator.dynamicresolver.qualifedType.QualifedTypeInjectedService;
+import org.glassfish.hk2.tests.locator.dynamicresolver.type.DynamicTypeResolver;
+import org.glassfish.hk2.tests.locator.dynamicresolver.type.TypeInjectedService;
+import org.glassfish.hk2.tests.locator.utilities.TestModule;
+import org.glassfish.hk2.utilities.BuilderHelper;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+public class DynamicResolverModule implements TestModule {
+
+    @Override
+    public void configure(DynamicConfiguration config) {
+        //optional injection
+        config.bind(BuilderHelper.link(OptionalNonDynamicTypeInjectedService.class)
+                .build());
+
+        config.bind(BuilderHelper.link(OptionalTypeInjectedService.class)
+                .build());
+
+        config.bind(BuilderHelper.link(OptionalQualifedInjectedService.class)
+                .build());
+
+        config.bind(BuilderHelper.link(OptionalQualifedTypeInjectedService.class)
+                .build());
+
+        //contract injection
+        config.bind(BuilderHelper.link(DynamicContractResolver.class)
+                .to(DynamicResolver.class)
+                .build());
+
+        config.bind(BuilderHelper.link(ContractInjectedService.class)
+                .build());
+
+        //type injection
+        config.bind(BuilderHelper.link(DynamicTypeResolver.class)
+                .to(DynamicResolver.class)
+                .build());
+
+        config.bind(BuilderHelper.link(TypeInjectedService.class)
+                .build());
+
+        //qualified injection
+        config.bind(BuilderHelper.link(DynamicQualifedResolver.class)
+                .to(DynamicResolver.class)
+                .qualifiedBy(DynamicQualifiedQualifer.class.getName())
+                .build());
+
+        config.bind(BuilderHelper.link(QualifedInjectedService.class)
+                .build());
+
+        //qualified type injection
+        config.bind(BuilderHelper.link(DynamicQualifedTypeResolver.class)
+                .to(DynamicResolver.class)
+                .qualifiedBy(DynamicQualifiedTypeQualifer.class.getName())
+                .build());
+
+        config.bind(BuilderHelper.link(QualifedTypeInjectedService.class)
+                .build());
+
+        //misc
+        config.bind(BuilderHelper.link(NonDynamicTypeInjectedService.class)
+                .build());
+
+        config.bind(BuilderHelper.link(UntypedAndUnqualifiedResolver.class)
+                .to(DynamicResolver.class)
+                .build());
+
+    }
+
+}

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/DynamicResolverTest.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/DynamicResolverTest.java
@@ -1,0 +1,126 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.tests.locator.dynamicresolver;
+
+import org.glassfish.hk2.api.MultiException;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.tests.locator.dynamicresolver.contract.ContractInjectedService;
+import org.glassfish.hk2.tests.locator.dynamicresolver.misc.NonDynamicTypeInjectedService;
+import org.glassfish.hk2.tests.locator.dynamicresolver.misc.OptionalNonDynamicTypeInjectedService;
+import org.glassfish.hk2.tests.locator.dynamicresolver.misc.OptionalQualifedInjectedService;
+import org.glassfish.hk2.tests.locator.dynamicresolver.misc.OptionalQualifedTypeInjectedService;
+import org.glassfish.hk2.tests.locator.dynamicresolver.misc.OptionalTypeInjectedService;
+import org.glassfish.hk2.tests.locator.dynamicresolver.qualifed.QualifedInjectedService;
+import org.glassfish.hk2.tests.locator.dynamicresolver.qualifedType.QualifedTypeInjectedService;
+import org.glassfish.hk2.tests.locator.dynamicresolver.type.TypeInjectedService;
+import org.glassfish.hk2.tests.locator.utilities.LocatorHelper;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+public class DynamicResolverTest {
+
+    private final static String TEST_NAME = "DynamicResolverTest";
+    private final static ServiceLocator locator = LocatorHelper.create(TEST_NAME, new DynamicResolverModule());
+
+    @Test(expected = MultiException.class)
+    public void testUndynamicTypeShouldThrowException() {
+        locator.getService(NonDynamicTypeInjectedService.class);
+    }
+
+    @Test
+    public void testUndynamicTypeShouldInjectNull() {
+        OptionalNonDynamicTypeInjectedService result = locator.getService(OptionalNonDynamicTypeInjectedService.class);
+        Assert.assertNotNull(result);
+        Assert.assertNull(result.getDynamic());
+    }
+
+    @Test
+    public void testDynamicContractResolution() {
+        ContractInjectedService result = locator.getService(ContractInjectedService.class);
+        Assert.assertNotNull(result);
+        Assert.assertNotNull(result.getDynamic());
+    }
+
+    @Test
+    public void testDynamicTypeResolution() {
+        TypeInjectedService result = locator.getService(TypeInjectedService.class);
+        Assert.assertNotNull(result);
+        Assert.assertNotNull(result.getDynamic());
+    }
+
+    @Test
+    public void testDynamicQualifedResolution() {
+        QualifedInjectedService result = locator.getService(QualifedInjectedService.class);
+        Assert.assertNotNull(result);
+        Assert.assertNotNull(result.getDynamic());
+    }
+
+    @Test
+    public void testDynamicQualifedTypeResolution() {
+        QualifedTypeInjectedService result = locator.getService(QualifedTypeInjectedService.class);
+        Assert.assertNotNull(result);
+        Assert.assertNotNull(result.getDynamic());
+    }
+
+    @Test
+    public void testOptionalDynamicTypeResolution() {
+        OptionalTypeInjectedService result = locator.getService(OptionalTypeInjectedService.class);
+        Assert.assertNotNull(result);
+        Assert.assertNotNull(result.getDynamic());
+    }
+
+    @Test
+    public void testOptionalDynamicQualifedResolution() {
+        OptionalQualifedInjectedService result = locator.getService(OptionalQualifedInjectedService.class);
+        Assert.assertNotNull(result);
+        Assert.assertNotNull(result.getDynamic());
+    }
+
+    @Test
+    public void testOptionalDynamicQualifedTypeResolution() {
+        OptionalQualifedTypeInjectedService result = locator.getService(OptionalQualifedTypeInjectedService.class);
+        Assert.assertNotNull(result);
+        Assert.assertNotNull(result.getDynamic());
+    }
+}

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/contract/ContractInjectedService.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/contract/ContractInjectedService.java
@@ -1,0 +1,63 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.tests.locator.dynamicresolver.contract;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+@Singleton
+public class ContractInjectedService {
+
+    private final DynamicContract dynamic;
+
+    @Inject
+    ContractInjectedService(DynamicContract dynamic) {
+        this.dynamic = dynamic;
+    }
+
+    public DynamicContract getDynamic() {
+        return dynamic;
+    }
+
+}

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/contract/DynamicContract.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/contract/DynamicContract.java
@@ -1,0 +1,49 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.tests.locator.dynamicresolver.contract;
+
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+public interface DynamicContract {
+
+}

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/contract/DynamicContractImpl.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/contract/DynamicContractImpl.java
@@ -1,0 +1,48 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.tests.locator.dynamicresolver.contract;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+public class DynamicContractImpl implements DynamicContract {
+
+}

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/contract/DynamicContractResolver.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/contract/DynamicContractResolver.java
@@ -1,0 +1,64 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.tests.locator.dynamicresolver.contract;
+
+import javax.inject.Singleton;
+import org.glassfish.hk2.api.DynamicInjectee;
+import org.glassfish.hk2.api.DynamicResolver;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+@Singleton
+public class DynamicContractResolver implements DynamicResolver<DynamicContract> {
+
+    @Override
+    public DynamicContract resolve(DynamicInjectee<DynamicContract> dynamic) {
+        assert dynamic != null;
+        assert DynamicContract.class.equals(dynamic.getType());
+        assert dynamic.getQualifiers().isEmpty();
+        assert dynamic.getParent() != null;
+        assert dynamic.getParentClass() != null;
+
+        return new DynamicContractImpl();
+    }
+
+}

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/misc/NonDynamicType.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/misc/NonDynamicType.java
@@ -1,0 +1,48 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.tests.locator.dynamicresolver.misc;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+public class NonDynamicType {
+
+}

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/misc/NonDynamicTypeInjectedService.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/misc/NonDynamicTypeInjectedService.java
@@ -1,0 +1,63 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.tests.locator.dynamicresolver.misc;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+@Singleton
+public class NonDynamicTypeInjectedService {
+
+    private final NonDynamicType dynamic;
+
+    @Inject
+    NonDynamicTypeInjectedService(NonDynamicType dynamic) {
+        this.dynamic = dynamic;
+    }
+
+    public NonDynamicType getDynamic() {
+        return dynamic;
+    }
+
+}

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/misc/OptionalNonDynamicTypeInjectedService.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/misc/OptionalNonDynamicTypeInjectedService.java
@@ -1,0 +1,64 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.tests.locator.dynamicresolver.misc;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.jvnet.hk2.annotations.Optional;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+@Singleton
+public class OptionalNonDynamicTypeInjectedService {
+
+    private final NonDynamicType dynamic;
+
+    @Inject
+    OptionalNonDynamicTypeInjectedService(@Optional NonDynamicType dynamic) {
+        this.dynamic = dynamic;
+    }
+
+    public NonDynamicType getDynamic() {
+        return dynamic;
+    }
+
+}

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/misc/OptionalQualifedInjectedService.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/misc/OptionalQualifedInjectedService.java
@@ -1,0 +1,66 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.tests.locator.dynamicresolver.misc;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.glassfish.hk2.tests.locator.dynamicresolver.qualifed.DynamicQualified;
+import org.glassfish.hk2.tests.locator.dynamicresolver.qualifed.DynamicQualifiedQualifer;
+import org.jvnet.hk2.annotations.Optional;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+@Singleton
+public class OptionalQualifedInjectedService {
+
+    private final DynamicQualified dynamic;
+
+    @Inject
+    OptionalQualifedInjectedService(@Optional @DynamicQualifiedQualifer DynamicQualified dynamic) {
+        this.dynamic = dynamic;
+    }
+
+    public DynamicQualified getDynamic() {
+        return dynamic;
+    }
+
+}

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/misc/OptionalQualifedTypeInjectedService.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/misc/OptionalQualifedTypeInjectedService.java
@@ -1,0 +1,67 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.tests.locator.dynamicresolver.misc;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.glassfish.hk2.tests.locator.dynamicresolver.qualifedType.DynamicQualifiedType;
+import org.glassfish.hk2.tests.locator.dynamicresolver.qualifedType.DynamicQualifiedTypeQualifer;
+import org.jvnet.hk2.annotations.Optional;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+@Singleton
+public class OptionalQualifedTypeInjectedService {
+
+    private final DynamicQualifiedType dynamic;
+
+    @Inject
+    OptionalQualifedTypeInjectedService(@Optional
+            @DynamicQualifiedTypeQualifer DynamicQualifiedType dynamic) {
+        this.dynamic = dynamic;
+    }
+
+    public DynamicQualifiedType getDynamic() {
+        return dynamic;
+    }
+
+}

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/misc/OptionalTypeInjectedService.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/misc/OptionalTypeInjectedService.java
@@ -1,0 +1,65 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.tests.locator.dynamicresolver.misc;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.glassfish.hk2.tests.locator.dynamicresolver.type.DynamicType;
+import org.jvnet.hk2.annotations.Optional;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+@Singleton
+public class OptionalTypeInjectedService {
+
+    private final DynamicType dynamic;
+
+    @Inject
+    OptionalTypeInjectedService(@Optional DynamicType dynamic) {
+        this.dynamic = dynamic;
+    }
+
+    public DynamicType getDynamic() {
+        return dynamic;
+    }
+
+}

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/misc/UntypedAndUnqualifiedResolver.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/misc/UntypedAndUnqualifiedResolver.java
@@ -1,0 +1,58 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.tests.locator.dynamicresolver.misc;
+
+import javax.inject.Singleton;
+import org.glassfish.hk2.api.DynamicInjectee;
+import org.glassfish.hk2.api.DynamicResolver;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+@Singleton
+public class UntypedAndUnqualifiedResolver implements DynamicResolver {
+
+    @Override
+    public Object resolve(DynamicInjectee dynamic) {
+        throw new AssertionError("Unexpected call to the resolver");
+    }
+
+}

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/qualifed/DynamicQualifedResolver.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/qualifed/DynamicQualifedResolver.java
@@ -1,0 +1,64 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.tests.locator.dynamicresolver.qualifed;
+
+import javax.inject.Singleton;
+import org.glassfish.hk2.api.DynamicInjectee;
+import org.glassfish.hk2.api.DynamicResolver;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+@Singleton
+@DynamicQualifiedQualifer
+public class DynamicQualifedResolver implements DynamicResolver {
+
+    @Override
+    public Object resolve(DynamicInjectee dynamic) {
+        assert dynamic != null;
+        assert !dynamic.getQualifiers().isEmpty();
+        assert dynamic.getParent() != null;
+        assert dynamic.getParentClass() != null;
+
+        return new DynamicQualified();
+    }
+
+}

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/qualifed/DynamicQualifedResolver.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/qualifed/DynamicQualifedResolver.java
@@ -49,12 +49,14 @@ import org.glassfish.hk2.api.DynamicResolver;
  */
 @Singleton
 @DynamicQualifiedQualifer
-public class DynamicQualifedResolver implements DynamicResolver {
+public class DynamicQualifedResolver implements DynamicResolver<Object> {
 
     @Override
-    public Object resolve(DynamicInjectee dynamic) {
+    public Object resolve(DynamicInjectee<Object> dynamic) {
+        DynamicQualifiedQualifer qualifier = dynamic.getQualifier(DynamicQualifiedQualifer.class);
         assert dynamic != null;
         assert !dynamic.getQualifiers().isEmpty();
+        assert qualifier != null;
         assert dynamic.getParent() != null;
         assert dynamic.getParentClass() != null;
 

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/qualifed/DynamicQualified.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/qualifed/DynamicQualified.java
@@ -1,0 +1,49 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.tests.locator.dynamicresolver.qualifed;
+
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+public class DynamicQualified {
+
+}

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/qualifed/DynamicQualifiedQualifer.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/qualifed/DynamicQualifiedQualifer.java
@@ -1,0 +1,60 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.tests.locator.dynamicresolver.qualifed;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import java.lang.annotation.Target;
+import javax.inject.Qualifier;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+@Qualifier
+@Retention(RUNTIME)
+@Target({TYPE, METHOD, FIELD, PARAMETER})
+public @interface DynamicQualifiedQualifer {
+
+}

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/qualifed/QualifedInjectedService.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/qualifed/QualifedInjectedService.java
@@ -1,0 +1,63 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.tests.locator.dynamicresolver.qualifed;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+@Singleton
+public class QualifedInjectedService {
+
+    private final DynamicQualified dynamic;
+
+    @Inject
+    QualifedInjectedService(@DynamicQualifiedQualifer DynamicQualified dynamic) {
+        this.dynamic = dynamic;
+    }
+
+    public DynamicQualified getDynamic() {
+        return dynamic;
+    }
+
+}

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/qualifedType/DynamicQualifedTypeResolver.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/qualifedType/DynamicQualifedTypeResolver.java
@@ -1,0 +1,65 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.tests.locator.dynamicresolver.qualifedType;
+
+import javax.inject.Singleton;
+import org.glassfish.hk2.api.DynamicInjectee;
+import org.glassfish.hk2.api.DynamicResolver;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+@Singleton
+@DynamicQualifiedTypeQualifer
+public class DynamicQualifedTypeResolver implements DynamicResolver<DynamicQualifiedType> {
+
+    @Override
+    public DynamicQualifiedType resolve(DynamicInjectee<DynamicQualifiedType> dynamic) {
+        assert dynamic != null;
+        assert DynamicQualifiedType.class.equals(dynamic.getType());
+        assert !dynamic.getQualifiers().isEmpty();
+        assert dynamic.getParent() != null;
+        assert dynamic.getParentClass() != null;
+
+        return new DynamicQualifiedType();
+    }
+
+}

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/qualifedType/DynamicQualifedTypeResolver.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/qualifedType/DynamicQualifedTypeResolver.java
@@ -53,9 +53,11 @@ public class DynamicQualifedTypeResolver implements DynamicResolver<DynamicQuali
 
     @Override
     public DynamicQualifiedType resolve(DynamicInjectee<DynamicQualifiedType> dynamic) {
+        DynamicQualifiedTypeQualifer qualifier = dynamic.getQualifier(DynamicQualifiedTypeQualifer.class);
         assert dynamic != null;
         assert DynamicQualifiedType.class.equals(dynamic.getType());
         assert !dynamic.getQualifiers().isEmpty();
+        assert qualifier != null;
         assert dynamic.getParent() != null;
         assert dynamic.getParentClass() != null;
 

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/qualifedType/DynamicQualifiedType.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/qualifedType/DynamicQualifiedType.java
@@ -1,0 +1,48 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.tests.locator.dynamicresolver.qualifedType;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+public class DynamicQualifiedType {
+
+}

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/qualifedType/DynamicQualifiedTypeQualifer.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/qualifedType/DynamicQualifiedTypeQualifer.java
@@ -1,0 +1,60 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.tests.locator.dynamicresolver.qualifedType;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.ElementType.TYPE;
+import java.lang.annotation.Retention;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import java.lang.annotation.Target;
+import javax.inject.Qualifier;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+@Qualifier
+@Retention(RUNTIME)
+@Target({TYPE, METHOD, FIELD, PARAMETER})
+public @interface DynamicQualifiedTypeQualifer {
+
+}

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/qualifedType/QualifedTypeInjectedService.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/qualifedType/QualifedTypeInjectedService.java
@@ -1,0 +1,63 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.tests.locator.dynamicresolver.qualifedType;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+@Singleton
+public class QualifedTypeInjectedService {
+
+    private final DynamicQualifiedType dynamic;
+
+    @Inject
+    QualifedTypeInjectedService(@DynamicQualifiedTypeQualifer DynamicQualifiedType dynamic) {
+        this.dynamic = dynamic;
+    }
+
+    public DynamicQualifiedType getDynamic() {
+        return dynamic;
+    }
+
+}

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/type/DynamicType.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/type/DynamicType.java
@@ -1,0 +1,48 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.tests.locator.dynamicresolver.type;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+public class DynamicType {
+
+}

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/type/DynamicTypeResolver.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/type/DynamicTypeResolver.java
@@ -1,0 +1,64 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.tests.locator.dynamicresolver.type;
+
+import javax.inject.Singleton;
+import org.glassfish.hk2.api.DynamicInjectee;
+import org.glassfish.hk2.api.DynamicResolver;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+@Singleton
+public class DynamicTypeResolver implements DynamicResolver<DynamicType> {
+
+    @Override
+    public DynamicType resolve(DynamicInjectee<DynamicType> dynamic) {
+        assert dynamic != null;
+        assert DynamicType.class.equals(dynamic.getType());
+        assert dynamic.getQualifiers().isEmpty();
+        assert dynamic.getParent() != null;
+        assert dynamic.getParentClass() != null;
+
+        return new DynamicType();
+    }
+
+}

--- a/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/type/TypeInjectedService.java
+++ b/hk2-locator/src/test/java/org/glassfish/hk2/tests/locator/dynamicresolver/type/TypeInjectedService.java
@@ -1,0 +1,63 @@
+/*
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ * Copyright (c) 2014 Oracle and/or its affiliates. All rights reserved.
+ *
+ * The contents of this file are subject to the terms of either the GNU
+ * General Public License Version 2 only ("GPL") or the Common Development
+ * and Distribution License("CDDL") (collectively, the "License").  You
+ * may not use this file except in compliance with the License.  You can
+ * obtain a copy of the License at
+ * https://glassfish.dev.java.net/public/CDDL+GPL_1_1.html
+ * or packager/legal/LICENSE.txt.  See the License for the specific
+ * language governing permissions and limitations under the License.
+ *
+ * When distributing the software, include this License Header Notice in each
+ * file and include the License file at packager/legal/LICENSE.txt.
+ *
+ * GPL Classpath Exception:
+ * Oracle designates this particular file as subject to the "Classpath"
+ * exception as provided by Oracle in the GPL Version 2 section of the License
+ * file that accompanied this code.
+ *
+ * Modifications:
+ * If applicable, add the following below the License Header, with the fields
+ * enclosed by brackets [] replaced by your own identifying information:
+ * "Portions Copyright [year] [name of copyright owner]"
+ *
+ * Contributor(s):
+ * If you wish your version of this file to be governed by only the CDDL or
+ * only the GPL Version 2, indicate your decision by adding "[Contributor]
+ * elects to include this software in this distribution under the [CDDL or GPL
+ * Version 2] license."  If you don't indicate a single choice of license, a
+ * recipient has the option to distribute your version of this file under
+ * either the CDDL, the GPL Version 2 or to extend the choice of license to
+ * its licensees as provided above.  However, if you add GPL Version 2 code
+ * and therefore, elected the GPL Version 2 license, then the option applies
+ * only if the new code is made subject to such option by the copyright
+ * holder.
+ */
+package org.glassfish.hk2.tests.locator.dynamicresolver.type;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ *
+ * @author Sharmarke Aden (saden)
+ */
+@Singleton
+public class TypeInjectedService {
+
+    private final DynamicType dynamic;
+
+    @Inject
+    TypeInjectedService(DynamicType dynamic) {
+        this.dynamic = dynamic;
+    }
+
+    public DynamicType getDynamic() {
+        return dynamic;
+    }
+
+}

--- a/src/site/markdown/dynamic-resolver-example.md
+++ b/src/site/markdown/dynamic-resolver-example.md
@@ -129,7 +129,7 @@ public class Flight {
 ```
 
 Note that unless we have added a service or factory qualified with @Boeing the Plane injection above will not be
-resolved. Once again we can turn to dynamic injection to help us dynamically create a qualified instances:
+resolved. Once again we can turn to dynamic injection to help us dynamically create qualified instances:
 
 ```java
 @Boeing
@@ -147,18 +147,18 @@ public class BoeingDynamicResolver implements DynamicResolver<Object> {
 ```
 
 In the BoeingDynamicResolver above notice that we have placed the @Boeing qualifier on the resolver and
-neglect to specify the dynamic resolver type parameter. By placing a @Boeing qualifier on the resolver and
-using omitting the type parameter we are telling the system the resolver can satisfy the injection
-of any type qualified with @Boeing. Of course, with the flexibility of being able to handle any type comes
-the responsibility of ensuring the object returned by the resolver can be injected safely into the injection point.
+neglect to specify the type parameter. By placing a @Boeing qualifier on the resolver and omitting the
+type parameter we are telling the system the resolver can satisfy the injection of any type qualified with
+@Boeing. Of course, with the flexibility of being able to handle any type comes the responsibility of
+ensuring the object returned by the resolver can be injected safely into the injection point.
 
 Note that dynamic qualified injection resolution does not limited you to a single qualifier. You can use
 multiple qualifiers on injection points and as long as these qualifiers are placed on your DynamicResolver
-implementation resolution will be satisfied by your dynamic resolver.
+implementation injection resolution will be satisfied by your dynamic resolver.
 
 Also note that placing qualifiers on DynamicResolver implementations is for hinting purpose only. Qualifiers
-on injection points on the other hand might be something you are interested and therefore are accessible from
-the DynamicInjectee parameter.
+on injection points on the other hand might be something you are interested and are therefore are accessible
+from the DynamicInjectee parameter.
 
 
 ### Dynamic Qualified Type Injection
@@ -199,10 +199,10 @@ public class Traveler {
 }
 ```
 
-Once again, there is no @Airline qualified Flight service in the system and so we will resort to using
-dynamic resolver to resolve it. Unlike the previous dynamic qualified injection example where we resolved
-any type qualified with @Boeing with dynamic qualified type injection we are only interested in resolving
-an explicit type (Flight) qualified with an explicity qualifier (@Airline).
+Once again, there is no @Airline qualified Flight service in the system and so we will resort to using a
+dynamic resolver. Unlike the previous dynamic qualified injection example where we resolved any type qualified
+with @Boeing with dynamic qualified type injection we are only interested in resolving an explicit type
+(Flight) qualified with an explicity qualifier (@Airline).
 
 
 ```java
@@ -231,10 +231,10 @@ only satisfy the injection of Flight types qualified with @Airline.
 Now that we have learned about the various kinds of dynamic injection it is important to understand
 how dynamic resolution works. When an unsatisfiable injectee is encountered the dynamic resolution
 process starts with the most restrictive premise, we are trying to perform a Dynamic Qualified Type
-injection. If a resolver is not found for the injectee's type and qualifiers then we look for an
-Dynamic Qualified resolver. If again a dynamic resolver for the injectee's qualifiers is not found
-we perform a last ditch effort and look for Dynamic Type resolver. If we still unable to find a dynamic
-resolver for the injectee's type then the injectee can not be resolved and [UnsatisfiedDependencyException][usde]
+injection. If a resolver is not found for the injectee's type and qualifiers then we look for a Dynamic
+Qualified resolver. If again a dynamic resolver for the injectee's qualifiers is not found we perform
+a last ditch effort and look for Dynamic Type resolver. If we are still unable to find a dynamic resolver
+for the injectee's type then the injectee can not be resolved and [UnsatisfiedDependencyException][usde]
 will be thrown.
 
 

--- a/src/site/markdown/dynamic-resolver-example.md
+++ b/src/site/markdown/dynamic-resolver-example.md
@@ -1,0 +1,254 @@
+## Dynamic Injection Resolver Example
+
+Dynamic Injection allow users to customize in some way the standard JSR-330 injection resolution.
+Using simple examples we will illustrates three kinds of dynamic injection:
+
+1. Dynamic Type Injection
+1. Dynamic Qualified Injection
+1. Dynamic Qualified Type Injection
+
+
+### Dynamic Type Injection
+
+Dynamic Type injection resolution is driven by the desire to dynamically resolve a specific type. Suppose we
+have the following interface:
+
+```java
+public interface Engine {
+
+    String getManufacturer();
+
+    int getThrust();
+
+}
+```
+
+Now suppose this Engine contract is injected into a Plane Service:
+
+```java
+    @Service
+    public class Plane {
+
+        private final Engine engine;
+
+        @Inject
+        Plane(Engine engine) {
+            this.engine = engine;
+        }
+    }
+```
+
+Under normal circumstances the Engine contract will not be satisfied by the standard JSR-330 resolver unless
+an Engine service or factory implementation is added to the [ServiceLocator][servicelocator]. That is to say if
+we were to retrieve the Plane service from the [ServiceLocator][servicelocator] or inject it to another service we
+will encounter [UnsatisfiedDependencyException][usde].
+
+This is where dynamic injection comes in handy. Instead of having to explicitly define and add an Engine
+service or Engine factory implementation to the [ServiceLocator][servicelocator] we can simply create an
+[DynamicResolver][dynamicresolver] implementation that facilitates dynamic resolution of an Engine. First let's
+create an Engine implementation:
+
+```java
+public class EngineImpl implements Engine {
+
+    private final String manufacturer;
+    private final int thrust;
+
+    public EngineImpl(String manufacturer, int thrust) {
+        this.manufacturer = manufacturer;
+        this.thrust = thrust;
+    }
+
+    @Override
+    public String getManufacturer() {
+        return manufacturer;
+    }
+
+    @Override
+    public int getThrust() {
+        return thrust;
+    }
+
+}
+```
+
+Now let's create an Engine type dynamic resolver:
+
+```java
+@Service
+public class EngineTypeDynamicResolver implements DynamicResolver<Engine> {
+
+    @Override
+    public Engine resolve(DynamicInjectee<Engine> injectee) {
+        //create a new Engine instance dynamically. note that you can inject
+        //services into the resolver to help you construct or retrieve an Engine.
+        return new EngineImpl("Pratt & Whitney", 98000);
+    }
+
+}
+```
+
+Note that the above [DynamicResolver][dynamicresolver] implementation is just a regular Singleton scoped service that
+takes the type it resolves (Engine) as its type parameter. Once the EngineTypeDynamicResolver is added to the ServiceLocator
+any service that requires injection of an Engine will result in EngineTypeDynamicResolver being utilized to resolve and
+provide an Engine instance.
+
+### Dynamic Qualified Injection
+
+While Dynamic Type injection deals with type based resolution, Dynamic Qualified injection deals with
+[Qualifier][qualifier] based resolution. Suppose we are interested in handling resolution of any type
+annotated with the following qualifier:
+
+```java
+@Qualifier
+@Retention(RUNTIME)
+@Target({TYPE, METHOD, FIELD, PARAMETER})
+public @interface Boeing {
+
+}
+```
+
+Now let's suppose we inject an instance of the Plane service into a Flight service using the above @Boeing qualifier:
+
+```java
+@Service
+public class Flight {
+
+    private final Plane plane;
+
+    @Inject
+    Flight(@Boeing Plane plane) {
+        this.plane = plane;
+    }
+
+    public Plane getPlane() {
+        return plane;
+    }
+
+}
+```
+
+Note that unless we have added a service or factory qualified with @Boeing the Plane injection above will not be
+resolved. Once again we can turn to dynamic injection to help us dynamically create a qualified instances:
+
+```java
+@Boeing
+@Service
+public class BoeingDynamicResolver implements DynamicResolver<Object> {
+
+    @Override
+    public Object resolve(DynamicInjectee<Object> injectee) {
+        //create a new Plane from scratch. note that you can inject services
+        //into the resolver to help you construct or retrieve Plane instances.
+        return new Plane(new EngineImpl("Royce Royce", 93000));
+    }
+
+}
+```
+
+In the BoeingDynamicResolver above notice that we have placed the @Boeing qualifier on the resolver and
+neglect to specify the dynamic resolver type parameter. By placing a @Boeing qualifier on the resolver and
+using omitting the type parameter we are telling the system the resolver can satisfy the injection
+of any type qualified with @Boeing. Of course, with the flexibility of being able to handle any type comes
+the responsibility of ensuring the object returned by the resolver can be injected safely into the injection point.
+
+Note that dynamic qualified injection resolution does not limited you to a single qualifier. You can use
+multiple qualifiers on injection points and as long as these qualifiers are placed on your DynamicResolver
+implementation resolution will be satisfied by your dynamic resolver.
+
+Also note that placing qualifiers on DynamicResolver implementations is for hinting purpose only. Qualifiers
+on injection points on the other hand might be something you are interested and therefore are accessible from
+the DynamicInjectee parameter.
+
+
+### Dynamic Qualified Type Injection
+
+As you might have guessed Dynamic Qualified Type Injection combines the functionality of Dynamic Type Injection
+and Dynamic Qualified Injection we have demonstrated so far. Suppose we are interested in handling resolution of
+Flight type annotated with the following qualifier:
+
+```java
+@Qualifier
+@Retention(RUNTIME)
+@Target({TYPE, METHOD, FIELD, PARAMETER})
+public @interface Airline {
+
+    String value() default "";
+}
+
+```
+
+Now suppose we inject an instance of a Flight service into a Traveler service using the above
+Airline qualifier:
+
+```java
+@Service
+public class Traveler {
+
+    private final Flight flight;
+
+    @Inject
+    Traveler(@Airline("United") Flight flight) {
+        this.flight = flight;
+    }
+
+    public Flight getFlight() {
+        return flight;
+    }
+
+}
+```
+
+Once again, there is no @Airline qualified Flight service in the system and so we will resort to using
+dynamic resolver to resolve it. Unlike the previous dynamic qualified injection example where we resolved
+any type qualified with @Boeing with dynamic qualified type injection we are only interested in resolving
+an explicit type (Flight) qualified with an explicity qualifier (@Airline).
+
+
+```java
+@Airline
+@Service
+public class AirlineFlightDynamicResolver implements DynamicResolver<Flight> {
+
+    @Override
+    public Flight resolve(DynamicInjectee<Flight> injectee) {
+        //create a new Flight from scratch. note that you can inject services
+        //into the resolver to help you construct or retrieve Flight instances.
+        return new Flight(new Plane(new EngineImpl("Royce Royce", 93000)));
+    }
+
+}
+```
+
+In the AirlineFlightDynamicResolver above notice that we have placed the @Airline qualifier on the
+resolver and specified Flight as the dynamic type parameter. Again, by placing a @Airline qualifier
+on the resolver and using Flight as our type parameter we are telling the system the resolver can
+only satisfy the injection of Flight types qualified with @Airline.
+
+
+### Dynamic Resolution Process
+
+Now that we have learned about the various kinds of dynamic injection it is important to understand
+how dynamic resolution works. When an unsatisfiable injectee is encountered the dynamic resolution
+process starts with the most restrictive premise, we are trying to perform a Dynamic Qualified Type
+injection. If a resolver is not found for the injectee's type and qualifiers then we look for an
+Dynamic Qualified resolver. If again a dynamic resolver for the injectee's qualifiers is not found
+we perform a last ditch effort and look for Dynamic Type resolver. If we still unable to find a dynamic
+resolver for the injectee's type then the injectee can not be resolved and [UnsatisfiedDependencyException][usde]
+will be thrown.
+
+
+### Conclusion
+
+In the examples above we have learned how to create and utilize dynamic injection to dynamically
+satisfy type, qualified and qualified type injections. For a certain classes of problems that require
+dynamic configuration dynamic injection be a powerful tool. If you are interested in exploring this
+topic more please take a look at the [examples][dynamicexample].
+
+
+[usde]: apidocs/org/glassfish/hk2/api/UnsatisfiedDependencyException.html
+[servicelocator]: apidocs/org/glassfish/hk2/api/ServiceLocator.html
+[dynamicresolver]: apidocs/org/glassfish/hk2/api/DynamicResolver.html
+[dynamicresolver]: apidocs/org/glassfish/hk2/api/DynamicResolver.html
+[qualifier]: http://docs.oracle.com/javaee/6/api/javax/inject/Qualifier.html
+[dynamicexample]: https://github.com/hk2-project/hk2/tree/master/examples/dynamic-resolver

--- a/src/site/markdown/extensibility.md
+++ b/src/site/markdown/extensibility.md
@@ -18,6 +18,7 @@ overview of each feature.  Among the set of HK2 features are:
 + [InheritableThread Scope](extensibility.html#InheritableThread_Scope)
 + [Proxies](extensibility.html#Proxies)
 + [Dealing with ClassLoading issues](extensibility.html#)
++ [Dynamic Injection Resolvers](extensibility.html#aDynamic_Injection_Resolvers)
 + [Custom Injection Resolvers](extensibility.html#aCustom_Injection_Resolvers)
 + [Validation](extensibility.html#Validation)
 + [Instance Lifecycle](extensibility.html#Instance_Lifecycle)
@@ -216,6 +217,17 @@ the [Descriptor][descriptor] is being reified.  It might also be possible to hav
 or construct the class dynamically using weaving or some other class building technology.
 The mind boggles at all the ways [HK2Loader][hk2loader] can be implemented.
 
+### Dynamic Injection Resolvers
+
+By default the system provides JSR-330 standard injection. Sometimes, however, it might be desirable
+to subvert the standard [@Inject][javaxinject] resolution processes with your own custom [@Inject][javaxinject] resolution.
+
+In order to do so, the user implements [DynamicResolver][dynamicresolver].
+The parameterized type of the [DynamicResolver][dynamicresolver] must be the injection type that they will resolve.
+The user implementation of [DynamicResolver][dynamicresolver] is then bound into a [ServiceLocator][servicelocator] like any other singleton service.
+
+Please take a look at the [dynamic resolver example][dynamic-resolver-example] for a more thorough explanation.
+
 ### Custom Injection Resolvers
 
 By default the system provides JSR-330 standard injection.
@@ -358,11 +370,13 @@ Using the [ErrorService][errorservice] can be a convenient place to standardize 
 [javaxinject]: http://docs.oracle.com/javaee/6/api/javax/inject/Inject.html
 [injectionresolver]: apidocs/org/glassfish/hk2/api/InjectionResolver.html
 [injectionpointindicator]: apidocs/org/glassfish/hk2/api/InjectionPointIndicator.html
+[dynamicresolver]: apidocs/org/glassfish/hk2/api/DynamicResolver.html
 [validationservice]: apidocs/org/glassfish/hk2/api/ValidationService.html
 [security-lockdown-example-runner]: security-lockdown-example-runner.html
 [instancelifecyclelistener]: apidocs/org/glassfish/hk2/api/InstanceLifecycleListener.html
 [classanalyzer]: apidocs/org/glassfish/hk2/api/ClassAnalyzer.html
 [custom-resolver-example]: custom-resolver-example.html
+[dynamic-resolver-example]: dynamic-resolver-example.html
 [runlevelservices]: runlevel.html
 [activedescriptor]: apidocs/org/glassfish/hk2/api/ActiveDescriptor.html
 [dynamicconfigurationlistener]: apidocs/org/glassfish/hk2/api/DynamicConfigurationListener.html

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -12,6 +12,7 @@ features allowing the users to connect with other container technologies<br/>
 <li>Custom lifecycles and scopes</li>
 <li>Events</li>
 <li>AOP and other proxies</li>
+<li>Dynamic injection resolution</li>
 <li>Custom injection resolution</li>
 <li>Assisted injection</li>
 <li>Just In Time injection resolution</li>


### PR DESCRIPTION
The current way of performing dynamic @Inject resolution in HK2 requires one to subvert the standard ThreeThirtyResolver with their own custom implementation and utilizing the ThreeThirtyResolver under the hood to resolve any injections the custom resolver can not resolve. While this mechanism is powerful it is too complex for the most common and desirable types of dynamic resolution. This pull request introduces a new Dynamic Resolver API that facilities resolution of unsatisfiable @Inject based injections through the standard JSR-330 process.

I have added an example page, test cases and an  example project that demonstrates this new API. Please review this pull request and let me know what you think. For clarity here is the content of the example page:

- - -

## Dynamic Injection Resolver Example

Dynamic Injection allow users to customize in some way the standard JSR-330 injection resolution.
Using simple examples we will illustrates three kinds of dynamic injection:

1. Dynamic Type Injection
1. Dynamic Qualified Injection
1. Dynamic Qualified Type Injection


### Dynamic Type Injection

Dynamic Type injection resolution is driven by the desire to dynamically resolve a specific type. Suppose we have the following interface:

```java
public interface Engine {

    String getManufacturer();

    int getThrust();

}
```

Now suppose this Engine contract is injected into a Plane Service:

```java
    @Service
    public class Plane {

        private final Engine engine;

        @Inject
        Plane(Engine engine) {
            this.engine = engine;
        }
    }
```

Under normal circumstances the Engine contract will not be satisfied by the standard JSR-330 resolver unless an Engine service or factory implementation is added to the [ServiceLocator][servicelocator]. That is to say if we were to retrieve the Plane service from the [ServiceLocator][servicelocator] or inject it to another service we will encounter [UnsatisfiedDependencyException][usde].

This is where dynamic injection comes in handy. Instead of having to explicitly define and add an Engine service or Engine factory implementation to the [ServiceLocator][servicelocator] we can simply create an [DynamicResolver][dynamicresolver] implementation that facilitates dynamic resolution of an Engine. First let's create an Engine implementation:

```java
public class EngineImpl implements Engine {

    private final String manufacturer;
    private final int thrust;

    public EngineImpl(String manufacturer, int thrust) {
        this.manufacturer = manufacturer;
        this.thrust = thrust;
    }

    @Override
    public String getManufacturer() {
        return manufacturer;
    }

    @Override
    public int getThrust() {
        return thrust;
    }

}
```

Now let's create an Engine type dynamic resolver:

```java
@Service
public class EngineTypeDynamicResolver implements DynamicResolver<Engine> {

    @Override
    public Engine resolve(DynamicInjectee<Engine> injectee) {
        //create a new Engine instance dynamically. note that you can inject
        //services into the resolver to help you construct or retrieve an Engine.
        return new EngineImpl("Pratt & Whitney", 98000);
    }

}
```

Note that the above [DynamicResolver][dynamicresolver] implementation is just a regular Singleton scoped service that takes the type it resolves (Engine) as its type parameter. Once the EngineTypeDynamicResolver is added to the ServiceLocator any service that requires injection of an Engine will result in EngineTypeDynamicResolver being utilized to resolve and provide an Engine instance.

### Dynamic Qualified Injection

While Dynamic Type injection deals with type based resolution, Dynamic Qualified injection deals with
[Qualifier][qualifier] based resolution. Suppose we are interested in handling resolution of any type annotated with the following qualifier:

```java
@Qualifier
@Retention(RUNTIME)
@Target({TYPE, METHOD, FIELD, PARAMETER})
public @interface Boeing {

}
```

Now let's suppose we inject an instance of the Plane service into a Flight service using the above @Boeing qualifier:

```java
@Service
public class Flight {

    private final Plane plane;

    @Inject
    Flight(@Boeing Plane plane) {
        this.plane = plane;
    }

    public Plane getPlane() {
        return plane;
    }

}
```

Note that unless we have added a service or factory qualified with @Boeing the Plane injection above will not be resolved. Once again we can turn to dynamic injection to help us dynamically create qualified instances:

```java
@Boeing
@Service
public class BoeingDynamicResolver implements DynamicResolver<Object> {

    @Override
    public Object resolve(DynamicInjectee<Object> injectee) {
        //create a new Plane from scratch. note that you can inject services
        //into the resolver to help you construct or retrieve Plane instances.
        return new Plane(new EngineImpl("Royce Royce", 93000));
    }

}
```

In the BoeingDynamicResolver above notice that we have placed the @Boeing qualifier on the resolver and neglect to specify the type parameter. By placing a @Boeing qualifier on the resolver and omitting the type parameter we are telling the system the resolver can satisfy the injection of any type qualified with @Boeing. Of course, with the flexibility of being able to handle any type comes the responsibility of
ensuring the object returned by the resolver can be injected safely into the injection point.

Note that dynamic qualified injection resolution does not limited you to a single qualifier. You can use
multiple qualifiers on injection points and as long as these qualifiers are placed on your DynamicResolver implementation injection resolution will be satisfied by your dynamic resolver.

Also note that placing qualifiers on DynamicResolver implementations is for hinting purpose only. Qualifiers on injection points on the other hand might be something you are interested and are therefore are accessible from the DynamicInjectee parameter.


### Dynamic Qualified Type Injection

As you might have guessed Dynamic Qualified Type Injection combines the functionality of Dynamic Type Injection and Dynamic Qualified Injection we have demonstrated so far. Suppose we are interested in handling resolution of Flight type annotated with the following qualifier:

```java
@Qualifier
@Retention(RUNTIME)
@Target({TYPE, METHOD, FIELD, PARAMETER})
public @interface Airline {

    String value() default "";
}

```

Now suppose we inject an instance of a Flight service into a Traveler service using the above Airline qualifier:

```java
@Service
public class Traveler {

    private final Flight flight;

    @Inject
    Traveler(@Airline("United") Flight flight) {
        this.flight = flight;
    }

    public Flight getFlight() {
        return flight;
    }

}
```

Once again, there is no @Airline qualified Flight service in the system and so we will resort to using a
dynamic resolver. Unlike the previous dynamic qualified injection example where we resolved any type qualified with @Boeing with dynamic qualified type injection we are only interested in resolving an explicit type (Flight) qualified with an explicity qualifier (@Airline).


```java
@Airline
@Service
public class AirlineFlightDynamicResolver implements DynamicResolver<Flight> {

    @Override
    public Flight resolve(DynamicInjectee<Flight> injectee) {
        //create a new Flight from scratch. note that you can inject services
        //into the resolver to help you construct or retrieve Flight instances.
        return new Flight(new Plane(new EngineImpl("Royce Royce", 93000)));
    }

}
```

In the AirlineFlightDynamicResolver above notice that we have placed the @Airline qualifier on the
resolver and specified Flight as the dynamic type parameter. Again, by placing a @Airline qualifier
on the resolver and using Flight as our type parameter we are telling the system the resolver can
only satisfy the injection of Flight types qualified with @Airline.


### Dynamic Resolution Process

Now that we have learned about the various kinds of dynamic injection it is important to understand
how dynamic resolution works. When an unsatisfiable injectee is encountered the dynamic resolution
process starts with the most restrictive premise, we are trying to perform a Dynamic Qualified Type
injection. If a resolver is not found for the injectee's type and qualifiers then we look for a Dynamic
Qualified resolver. If again a dynamic resolver for the injectee's qualifiers is not found we perform
a last ditch effort and look for Dynamic Type resolver. If we are still unable to find a dynamic resolver
for the injectee's type then the injectee can not be resolved and [UnsatisfiedDependencyException][usde] will be thrown.


### Conclusion

In the examples above we have learned how to create and utilize dynamic injection to dynamically
satisfy type, qualified and qualified type injections. For a certain classes of problems that require
dynamic configuration dynamic injection be a powerful tool. If you are interested in exploring this
topic more please take a look at the [examples][dynamicexample].


[usde]: apidocs/org/glassfish/hk2/api/UnsatisfiedDependencyException.html
[servicelocator]: apidocs/org/glassfish/hk2/api/ServiceLocator.html
[dynamicresolver]: apidocs/org/glassfish/hk2/api/DynamicResolver.html
[dynamicresolver]: apidocs/org/glassfish/hk2/api/DynamicResolver.html
[qualifier]: http://docs.oracle.com/javaee/6/api/javax/inject/Qualifier.html
[dynamicexample]: https://github.com/hk2-project/hk2/tree/master/examples/dynamic-resolver